### PR TITLE
System Verilog code for 10bit Carry lookahead adder

### DIFF
--- a/Wallace5x5/final_adder.sv
+++ b/Wallace5x5/final_adder.sv
@@ -1,6 +1,33 @@
-// design a 10bit carry lookahead adder
-module final_adder(a, b, s);
-	input logic [9:0] a, b;
-	output logic [9:0] s;
-	//start from here
+// Design a 10-bit Carry Lookahead Adder
+module final_adder(
+    input logic [9:0] a,       // 10-bit input A
+    input logic [9:0] b,       // 10-bit input B
+    output logic [9:0] s,      // 10-bit sum output
+    output logic carry_out      
+);
+    logic [9:0] generate;      
+    logic [9:0] propagate;      
+    logic [10:0] carry;        
+
+    // Generate and Propagate Logic
+    assign generate = a & b;   
+    assign propagate = a | b;   
+
+    //logic
+    assign carry[0] = 1'b0;      //assumed to be 0
+    assign carry[1] = generate[0] | (propagate[0] & carry[0]);
+    assign carry[2] = generate[1] | (propagate[1] & carry[1]);
+    assign carry[3] = generate[2] | (propagate[2] & carry[2]);
+    assign carry[4] = generate[3] | (propagate[3] & carry[3]);
+    assign carry[5] = generate[4] | (propagate[4] & carry[4]);
+    assign carry[6] = generate[5] | (propagate[5] & carry[5]);
+    assign carry[7] = generate[6] | (propagate[6] & carry[6]);
+    assign carry[8] = generate[7] | (propagate[7] & carry[7]);
+    assign carry[9] = generate[8] | (propagate[8] & carry[8]);
+    assign carry_out = generate[9] | (propagate[9] & carry[9]); 
+
+    // sum Calculation
+    assign s = a ^ b ^ carry[9:0]; 
+
 endmodule
+


### PR DESCRIPTION
//test bench for this is
module tb_final_adder;

    logic [9:0] a, b;  // Test input vectors
    logic [9:0] s;     // Expected sum output
    logic carry_out;   // Expected carry output

    // Instantiate the CLA module
    final_adder uut (
        .a(a),
        .b(b),
        .s(s),
        .carry_out(carry_out)
    );

    initial begin
        // Test case 1
        a = 10'b0000111100; 
        b = 10'b0000000011; 
        #10;
        $display("A = %b, B = %b, Sum = %b, Carry_out = %b", a, b, s, carry_out);

        // Test case 2
        a = 10'b1111111111; 
        b = 10'b0000000001; 
        #10;
        $display("A = %b, B = %b, Sum = %b, Carry_out = %b", a, b, s, carry_out);

        // Test case 3
        a = 10'b0101010101; 
        b = 10'b1010101010; 
        #10;
        $display("A = %b, B = %b, Sum = %b, Carry_out = %b", a, b, s, carry_out);

        // Test case 4
        a = 10'b0000000000; 
        b = 10'b0000000000; 
        #10;
        $display("A = %b, B = %b, Sum = %b, Carry_out = %b", a, b, s, carry_out);

        // Test case 5
        a = 10'b1111111111; 
        b = 10'b1111111111; 
        #10;
        $display("A = %b, B = %b, Sum = %b, Carry_out = %b", a, b, s, carry_out);

        // End simulation
        $finish;
    end

endmodule
